### PR TITLE
Adds another soy file with a missing feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,14 @@
 </div>
 ```
 
+3) Passing HTML to other templates
+
+```
+{call .template}
+  {param content kind="html"}
+    <div class="content">Foo</div>
+  {/param}
+{/call}
+```
+
 For more information visit https://github.com/google/incremental-dom/issues/96.

--- a/soy/htmlParam.soy
+++ b/soy/htmlParam.soy
@@ -1,0 +1,21 @@
+{namespace soy.examples.htmlParam autoescape="strict"}
+
+/**
+ * @param foo
+ */
+{template .main}
+  {call .template}
+    {param content kind="html"}
+      <div class="content">{$foo}</div>
+    {/param}
+  {/call}
+{/template}
+
+/**
+ * @param content
+ */
+{template .template}
+  <div class="template">
+    {$content}
+  </div>
+{/template}

--- a/soy/htmlParam.soy.js
+++ b/soy/htmlParam.soy.js
@@ -1,0 +1,65 @@
+// This file was automatically generated from htmlParam.soy.
+// Please don't edit this file by hand.
+
+/**
+ * @fileoverview Templates in namespace soy.examples.htmlParam.
+ * @public
+ */
+
+goog.module('soy.examples.htmlParam.incrementaldom');
+
+goog.require('soy');
+goog.require('soydata');
+/** @suppress {extraRequire} */
+goog.require('goog.i18n.bidi');
+/** @suppress {extraRequire} */
+goog.require('goog.asserts');
+var IncrementalDom = goog.require('incrementaldom');
+var ie_open = IncrementalDom.elementOpen;
+var ie_close = IncrementalDom.elementClose;
+var ie_void = IncrementalDom.elementVoid;
+var ie_open_start = IncrementalDom.elementOpenStart;
+var ie_open_end = IncrementalDom.elementOpenEnd;
+var itext = IncrementalDom.text;
+var iattr = IncrementalDom.attr;
+
+
+/**
+ * @param {Object<string, *>=} opt_data
+ * @param {(null|undefined)=} opt_ignored
+ * @param {Object<string, *>=} opt_ijData
+ * @return {void}
+ * @suppress {checkTypes}
+ */
+function $main(opt_data, opt_ignored, opt_ijData) {
+  var param256 = function() {
+    ie_open('div', null, null,
+        'class', 'content');
+      itext((goog.asserts.assert((opt_data.foo) != null), opt_data.foo));
+    ie_close('div');
+  };
+  $template({content: param256}, null, opt_ijData);
+}
+exports.main = $main;
+if (goog.DEBUG) {
+  $main.soyTemplateName = 'soy.examples.htmlParam.main';
+}
+
+
+/**
+ * @param {Object<string, *>=} opt_data
+ * @param {(null|undefined)=} opt_ignored
+ * @param {Object<string, *>=} opt_ijData
+ * @return {void}
+ * @suppress {checkTypes}
+ */
+function $template(opt_data, opt_ignored, opt_ijData) {
+  ie_open('div', null, null,
+      'class', 'template');
+    itext((goog.asserts.assert((opt_data.content) != null), opt_data.content));
+  ie_close('div');
+}
+exports.template = $template;
+if (goog.DEBUG) {
+  $template.soyTemplateName = 'soy.examples.htmlParam.template';
+}

--- a/soy/simple.soy.js
+++ b/soy/simple.soy.js
@@ -71,13 +71,13 @@ if (goog.DEBUG) {
  * @suppress {checkTypes}
  */
 function $helloNames(opt_data, opt_ignored, opt_ijData) {
-  var nameList272 = opt_data.names;
-  var nameListLen272 = nameList272.length;
-  if (nameListLen272 > 0) {
-    for (var nameIndex272 = 0; nameIndex272 < nameListLen272; nameIndex272++) {
-      var nameData272 = nameList272[nameIndex272];
-      $helloName({name: nameData272}, null, opt_ijData);
-      if (! (nameIndex272 == nameListLen272 - 1)) {
+  var nameList283 = opt_data.names;
+  var nameListLen283 = nameList283.length;
+  if (nameListLen283 > 0) {
+    for (var nameIndex283 = 0; nameIndex283 < nameListLen283; nameIndex283++) {
+      var nameData283 = nameList283[nameIndex283];
+      $helloName({name: nameData283}, null, opt_ijData);
+      if (! (nameIndex283 == nameListLen283 - 1)) {
         ie_open('br');
         ie_close('br');
       }


### PR DESCRIPTION
Passing params with html content to other template calls doens't work right now. The compiled file correctly avoids running the html before passing it to the template, by wrapping it into a function. The template that gets the html param receives it as a function then, but it passes it directly to an `itext` call instead of calling it, so the function gets printed as text instead of actually rendering its markup.